### PR TITLE
To allow multiple shell scripts to be copied.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN curl --create-dirs -sSLo /usr/share/jenkins/swarm-client-${JENKINS_SWARM_VER
 COPY jenkins-slave.sh /usr/local/bin/jenkins-slave.sh
 
 RUN mkdir /docker-entrypoint-init.d
-ONBUILD ADD ./*.sh /docker-entrypoint-init.d
+ONBUILD ADD ./*.sh /docker-entrypoint-init.d/
 
 USER "${JENKINS_USER}"
 VOLUME "${JENKINS_HOME}"


### PR DESCRIPTION
If I put multiple shell scripts in my derived image I got this error on build:
"When using ADD with more than one source file, the destination must be a directory and end with a /"